### PR TITLE
working dockerfile with graalvm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+#############################
+#   Builder
+#############################
+FROM icgcargo/graalvm:java11-20.2.0-extras as builder
+WORKDIR /usr/src/app
+ADD . .
+RUN ./mvnw clean package -DskipTests
+
+#############################
+#   Server
+#############################
+FROM icgcargo/graalvm:java11-20.2.0-extras
+
+ENV APP_HOME /srv
+ENV APP_USER wfuser
+ENV APP_UID 9999
+ENV APP_GID 9999
+
+WORKDIR $APP_HOME
+
+COPY --from=builder /usr/src/app/target/workflow-graph-node-*.jar $APP_HOME/workflow-graph-node.jar
+
+RUN groupadd -g $APP_GID $APP_USER \
+    && useradd -u $APP_UID -g $APP_USER $APP_USER \
+    && chown -R $APP_UID:$APP_GID $APP_HOME
+
+USER $APP_UID
+
+CMD ["java", "-ea", "-jar", "/srv/workflow-graph-node.jar"]
+EXPOSE 8080/tcp


### PR DESCRIPTION
Some notes on we are using our own base image:
- Cannot use Oracle provided GraalVM image due to it being restricted to logged in users only
- Oracle provided GraalVM image does not appear to match their listed dockerfile due to system utilities missing that we need for the security concerns in kubernetes. 