### PR TITLE
fixes main class attribute in manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,18 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>
+                        org.icgc_argo.workflowgraphnode.WorkflowGraphNodeApplication
+                    </mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This is normally already provided by the spring boot parent pom but since we rolled our own we were missing this repackage step to point to our main class. 