### PR TITLE
Ensures Graph schemas are accessible in the content type storage.

### DIFF
--- a/src/main/java/org/icgc_argo/workflowgraphnode/config/AppConfig.java
+++ b/src/main/java/org/icgc_argo/workflowgraphnode/config/AppConfig.java
@@ -93,11 +93,6 @@ public class AppConfig {
   private void ensureGraphSchemas() {
     val schemaManager = this.reactiveRabbit.schemaManager();
 
-    Method registerMethod =
-        SchemaManager.class.getDeclaredMethod(
-            "importRegisteredSchema", String.class, Schema.class, Integer.class);
-    registerMethod.setAccessible(true);
-
     try {
       schemaManager.fetchReadSchemaByContentType(GRAPH_EVENT_CONTENT_TYPE);
     } catch (NullPointerException e) {

--- a/src/main/java/org/icgc_argo/workflowgraphnode/config/AppConfig.java
+++ b/src/main/java/org/icgc_argo/workflowgraphnode/config/AppConfig.java
@@ -6,16 +6,21 @@ import static java.util.Arrays.asList;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pivotal.rabbitmq.ReactiveRabbit;
 import com.pivotal.rabbitmq.schema.MissingAvroSchemaException;
+import com.pivotal.rabbitmq.schema.SchemaManager;
 import java.io.File;
 import java.io.FileInputStream;
+import java.lang.reflect.Method;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.avro.Schema;
+import org.icgc_argo.workflow_graph_lib.schema.*;
 import org.icgc_argo.workflow_graph_lib.workflow.client.RdpcClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -23,8 +28,12 @@ import org.springframework.core.env.Environment;
 @Slf4j
 @Configuration
 public class AppConfig {
+  private static final String GRAPH_EVENT_CONTENT_TYPE = "application/vnd.GraphEvent+avro";
+  private static final String GRAPH_RUN_CONTENT_TYPE = "application/vnd.GraphRun+avro";
+
   @Getter private final NodeProperties nodeProperties;
   private final ReactiveRabbit reactiveRabbit;
+  private final ApplicationContext context;
 
   @Value("${rdpc.url}")
   @Getter
@@ -35,15 +44,18 @@ public class AppConfig {
       @Value("${node.jsonConfigPath}") String jsonConfigPath,
       @Value("${node.localSchemaPath}") String localSchemaPath,
       @Autowired ReactiveRabbit reactiveRabbit,
-      @Autowired Environment environment) {
+      @Autowired Environment environment,
+      @Autowired ApplicationContext context) {
     val inputStream = new FileInputStream(jsonConfigPath);
     this.nodeProperties = new ObjectMapper().readValue(inputStream, NodeProperties.class);
     this.reactiveRabbit = reactiveRabbit;
+    this.context = context;
 
     val profiles = asList(environment.getActiveProfiles());
     if (profiles.contains("registry") && !profiles.contains("test")) {
       log.info("Loading workflow schema from Registry.");
       loadWorkflowSchemaFromRegistry();
+      ensureGraphSchemas();
     } else if (!profiles.contains("test")) {
       log.info("Loading workflow schema from file system.");
       loadWorkflowSchemaFromFileSystem(localSchemaPath);
@@ -73,6 +85,32 @@ public class AppConfig {
     }
   }
 
+  /**
+   * Make sure that the Graph schemas are loaded from classpath into the content type storage of the
+   * schema manager.
+   */
+  @SneakyThrows
+  private void ensureGraphSchemas() {
+    val schemaManager = this.reactiveRabbit.schemaManager();
+
+    Method registerMethod =
+        SchemaManager.class.getDeclaredMethod(
+            "importRegisteredSchema", String.class, Schema.class, Integer.class);
+    registerMethod.setAccessible(true);
+
+    try {
+      schemaManager.fetchReadSchemaByContentType(GRAPH_EVENT_CONTENT_TYPE);
+    } catch (NullPointerException e) {
+      classPathToContentTypeStorage(GRAPH_EVENT_CONTENT_TYPE, GraphEvent.SCHEMA$);
+    }
+
+    try {
+      schemaManager.fetchReadSchemaByContentType(GRAPH_RUN_CONTENT_TYPE);
+    } catch (NullPointerException e) {
+      classPathToContentTypeStorage(GRAPH_RUN_CONTENT_TYPE, GraphRun.SCHEMA$);
+    }
+  }
+
   @SneakyThrows
   private void loadWorkflowSchemaFromFileSystem(String localSchemaPath) {
     val schemaFullName =
@@ -92,6 +130,28 @@ public class AppConfig {
     if (storedSchema == null || storedSchema.isError()) {
       log.error("Cannot load required avro schema listed in workflow parameters from filesystem.");
       throw new MissingAvroSchemaException(schemaFullName);
+    }
+  }
+
+  @SneakyThrows
+  private void classPathToContentTypeStorage(String contentType, Schema schema) {
+    val schemaManager = this.reactiveRabbit.schemaManager();
+
+    Method registerMethod =
+        SchemaManager.class.getDeclaredMethod(
+            "importRegisteredSchema", String.class, Schema.class, Integer.class);
+    registerMethod.setAccessible(true);
+
+    log.info("Loading GraphRun AVRO Schema from classpath into registry with ContentType.");
+    registerMethod.invoke(schemaManager, contentType, schema, null);
+
+    val graphRunSchemaObj = schemaManager.fetchReadSchemaByContentType(contentType);
+    if (graphRunSchemaObj.isError()) {
+      log.error("Cannot load {} schema by Content Type, shutting down.", schema.getFullName());
+      SpringApplication.exit(context, () -> 1);
+    } else {
+      log.info("Successfully loaded schema {} from classpath.", graphRunSchemaObj.getFullName());
+      log.info("\n\033[32m" + graphRunSchemaObj.toString(true) + "\033[39m");
     }
   }
 


### PR DESCRIPTION
Fixes: https://github.com/icgc-argo/workflow-graph-node/issues/47

Uses: 
![image](https://user-images.githubusercontent.com/6350043/100263840-02f2fa00-2f1c-11eb-9992-90d796be0668.png)

Verified in debugger:
![Screenshot_20201125_122949](https://user-images.githubusercontent.com/6350043/100263909-18682400-2f1c-11eb-9b4a-6ef57eee97fd.png)


Output on startup:
![Screenshot_20201125_123025](https://user-images.githubusercontent.com/6350043/100263886-130ad980-2f1c-11eb-8b51-35860bc332b9.png)



