### PR TITLE
Workflows component delegates error handling to Errors component

### DIFF
--- a/src/main/java/org/icgc_argo/workflowgraphnode/service/GraphTransitAuthority.java
+++ b/src/main/java/org/icgc_argo/workflowgraphnode/service/GraphTransitAuthority.java
@@ -87,7 +87,8 @@ public class GraphTransitAuthority {
 
   /**
    * Commits the transaction and removes it's associated GraphTransitObject from the
-   * GraphTransitAuthority registry
+   * GraphTransitAuthority registry (should only be used in the Errors component or as the final
+   * subscribe consumer)
    *
    * @param tx the transaction to be committed and for which the corresponding GTO should be removed
    *     from the GTA
@@ -99,7 +100,7 @@ public class GraphTransitAuthority {
 
   /**
    * Rejects the transaction and removes it's associated GraphTransitObject from the
-   * GraphTransitAuthority registry
+   * GraphTransitAuthority registry (should only be used in the Errors component)
    *
    * @param tx the transaction to be rejected and for which the corresponding GTO should be removed
    *     from the GTA
@@ -111,7 +112,7 @@ public class GraphTransitAuthority {
 
   /**
    * Requeue (tx.rollback(true)) the transaction and removes it's associated GraphTransitObject from
-   * the GraphTransitAuthority registry
+   * the GraphTransitAuthority registry (should only be used in the Errors component)
    *
    * @param tx the transaction that will requeue and for which the corresponding GTO should be
    *     removed from the GTA

--- a/src/test/java/org/icgc_argo/workflowgraphnode/components/WorkflowsTest.java
+++ b/src/test/java/org/icgc_argo/workflowgraphnode/components/WorkflowsTest.java
@@ -89,12 +89,11 @@ public class WorkflowsTest {
                 })
             .collect(toList());
 
-    val handler = Workflows.handleRunStatus(rdpcClientMock);
-
     val source =
         Flux.fromIterable(runIdTransactions)
             .doOnNext(graphTransitAuthority::registerGraphRunTx)
-            .handle(handler);
+            .handle(Workflows.handleRunStatus(rdpcClientMock))
+            .onErrorContinue(Errors.handle());
 
     StepVerifier.create(source)
         // transaction 0 is sent to the next call unchanged in the flux handler


### PR DESCRIPTION
Closes #61 

The issue ultimately was that the Workflows component was doing the job of the Error component, this was an artifact of the time before we had the hierarchical error handling implementation that was not caught during the migration to the new logging approach. Ultimately the only place we should be doing anything with transactions (other than spawning) is in the final subscribe consumer for a given flux or in the Error component, basically where the flux's are meant to terminate.