### PR TITLE
change graph-lib version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <dependency>
             <groupId>org.icgc_argo</groupId>
             <artifactId>workflow-graph-lib</artifactId>
+            <version>1.11.0</version>
         </dependency>
 
         <!-- Logging -->


### PR DESCRIPTION
added the version tag to ensure the latest version of graph-lib is picked up at the time of image building